### PR TITLE
Set encryption to no

### DIFF
--- a/Freaks--iOS--Info.plist
+++ b/Freaks--iOS--Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleShortVersionString</key>
 	<string>$(APP_VERSION_STRING)</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
## Description
Set variable to no to indicate that our app does not use encryption

## Related
https://trello.com/c/iDvNYsck

## Documentation
https://developer.apple.com/documentation/bundleresources/information_property_list/itsappusesnonexemptencryption

## Link to demo

## Steps to Test or Reproduce