### PR TITLE
Fix freaks screen landscape bug

### DIFF
--- a/Shared/Features/Freaks/View/FreaksView.swift
+++ b/Shared/Features/Freaks/View/FreaksView.swift
@@ -42,6 +42,7 @@ struct FreaksView: View {
             }
             .modifier(NavbarTitle(title: "Freaks"))
         }
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 


### PR DESCRIPTION
## Description
Fix bug where freaks are not displayed in landscape

## Related
https://trello.com/c/QbXkzJPa

## Documentation

## Link to demo
https://imgur.com/MkwPyyA

## Steps to Test or Reproduce

1. Install app
2. Open app
3. Switch to landscape
