### PR TITLE
Fix freak details screen back button

### DIFF
--- a/Shared/Features/FreakDetails/View/FreakDetailsView.swift
+++ b/Shared/Features/FreakDetails/View/FreakDetailsView.swift
@@ -67,6 +67,7 @@ struct FreakDetailsView: View {
                 Image(systemName: "chevron.left")
                 Text(viewModel.fullName)
             }
+            .foregroundColor(Color("SecondaryColor"))
         })
     }
 }


### PR DESCRIPTION
## Description
Fixed missing back button on freaks details screen 

## Related
https://trello.com/c/ZXDGUljk

## Documentation

## Link to demo
https://imgur.com/rmBze9P

## Steps to Test or Reproduce

1.  Install app
2. Open app
3. Tap on freak

